### PR TITLE
Allow build of fresh clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ TDS-SRC-DIR=source/latex/pdfpages
 all: sty
 
 .PHONY: sty
-sty: ins
+sty: ins git-config smudge
 	latex pdfpages.ins
 
 .PHONY: ins
@@ -98,6 +98,18 @@ ifneq "$(shell git status --porcelain pdfpages.dtx)" ""
 endif
 	rm pdfpages.dtx
 	git checkout pdfpages.dtx
+
+.PHONY: git-config
+git-config:
+	git config filter.date_sha1.clean 'scripts/git_filter_date_sha1 --clean'
+	git config filter.date_sha1.smudge 'scripts/git_filter_date_sha1 --smudge'
+
+.PHONY: smudge
+smudge:
+ifeq '$(findstring $$Date: YYYY-MM-DD, $(file < pdfpages.dtx))' '$$Date: YYYY-MM-DD'
+	scripts/git_filter_date_sha1 --smudge <pdfpages.dtx >pdfpages-smudge.dtx
+	mv pdfpages-smudge.dtx pdfpages.dtx
+endif
 
 subdirs := test
 .PHONY: $(subdirs)

--- a/pdfpages.dtx
+++ b/pdfpages.dtx
@@ -31,8 +31,8 @@
 \def\AM@Git@Date@process$#1: #2 #3${\AM@Git@Date@process@i#2\END}
 \def\AM@Git@Date@process@i#1-#2-#3\END{\def\AM@Git@Date{#1/#2/#3}}
 \def\AM@Git@SHA@process$#1: #2${\def\AM@Git@SHA{#2}}
-\AM@Git@Date@process$Date:$
-\AM@Git@SHA@process$SHA-1:$
+\AM@Git@Date@process$Date: YYYY-MM-DD TIME $
+\AM@Git@SHA@process$SHA-1: xxxxxxx $
 %</!(example1,example2,example3,installer)>
 %
 %

--- a/scripts/git_filter_date
+++ b/scripts/git_filter_date
@@ -1,13 +1,11 @@
 #!/bin/bash
 
-if [ "$1" == "--smudge" ]
-then
+case "$1" in
+--smudge)
 	date=$(git log --pretty=format:"%ai" -1)
 	sed -e "s,\\\$Date:[^$]*\\\$,\\\$Date: $date \\\$,g"
-fi
-
-if [ "$1" == "--clean" ]
-then
-	sed -e "s,\\\$Date:[^\\\$]*\\\$,\\\$Date:\\\$,g"
-fi
-
+	;;
+--clean)
+	sed -e "s,\\\$Date:[^\\\$]*\\\$,\\\$Date: YYYY-MM-DD TIME \\\$,g"
+	;;
+esac

--- a/scripts/git_filter_sha1
+++ b/scripts/git_filter_sha1
@@ -1,13 +1,11 @@
 #!/bin/bash
 
-if [ "$1" == "--smudge" ]
-then
-	sha=$(git log -1 | cat | head -n 1 | cut -d' ' -f2)
+case "$1" in
+--smudge)
+	sha=$(git log -1 | head -n 1 | cut -d' ' -f2)
 	sed -e "s,\\\$SHA-1:[^$]*\\\$,\\\$SHA-1: $sha \\\$,g"
-fi
-
-if [ "$1" == "--clean" ]
-then
-	sed -e "s,\\\$SHA-1:[^\\\$]*\\\$,\\\$SHA-1:\\\$,g"
-fi
-
+	;;
+--clean)
+	sed -e "s,\\\$SHA-1:[^\\\$]*\\\$,\\\$SHA-1: xxxxxxx \\\$,g"
+	;;
+esac


### PR DESCRIPTION
Currently, when checking out this repository, `latex pdfpages.dtx` and thus `make tds` fail with

    ! Paragraph ended before \AM@Git@Date@process was complete.

Likewise for `make sty` and then using the style file.

This PR adds dummy values to the dtx to remedy this problem when running `latex` directly and uses the smudge script when operating via `make`.